### PR TITLE
Reduce per-page memory on PDF pipeline and fix low-memory backpressure

### DIFF
--- a/src/pipeline/helper_functions.rs
+++ b/src/pipeline/helper_functions.rs
@@ -652,7 +652,24 @@ pub enum MemoryPressure {
 }
 
 pub fn get_memory_monitor() -> &'static MemoryMonitor {
-    MEMORY_MONITOR.get_or_init(|| MemoryMonitor::new(DEFAULT_MEMORY_LIMIT_GB))
+    MEMORY_MONITOR.get_or_init(|| MemoryMonitor::new(adaptive_memory_limit_gb()))
+}
+
+/// Derive a memory limit that is meaningful on the machine actually running.
+///
+/// The pressure ratio used for backpressure is `current_usage / limit`, so a fixed
+/// 12 GB limit is useless on the 4–8 GB machines that actually run out of memory:
+/// `Critical` (ratio ≥ 0.9) would require ~10.8 GB of working set, which those
+/// machines can never reach before the OS kills the process. Scaling the limit to a
+/// fraction of physical RAM keeps backpressure (`wait_for_memory_relief`) engaging
+/// with headroom for the OS and other apps, while never exceeding the original
+/// ceiling on large machines.
+fn adaptive_memory_limit_gb() -> usize {
+    let total_ram_gb = get_available_ram_gb();
+    // Use ~70% of physical RAM as the working-set ceiling, clamped to a small floor so
+    // tiny/undetected configs still trip backpressure rather than overflowing, and to
+    // the historical default as the upper bound.
+    ((total_ram_gb * 7) / 10).clamp(3, DEFAULT_MEMORY_LIMIT_GB)
 }
 
 /// Wait for memory pressure to decrease below critical level.

--- a/src/pipeline/pdf_tokio_pipeline.rs
+++ b/src/pipeline/pdf_tokio_pipeline.rs
@@ -48,7 +48,6 @@ pub struct ProcessedPage {
     pub height: u32,
     pub elements: Vec<crate::accumulator::ContentElement>,
     pub hocr_text: Option<String>,
-    pub binarized: Option<Vec<u8>>, // None when OCR is disabled to free memory
 }
 
 #[derive(Clone, Debug)]
@@ -461,23 +460,25 @@ async fn process_single_page(
             .any(|d| d.category.force_generic_jbig2());
 
     // Encode base layer.
-    // - "jpeg" mode: encode the full RGB image (binarized holds luma for OCR storage only).
+    // - "jpeg" mode: encode the full RGB image (binarized held only the OCR luma above).
     // - Deferred path: binarize+encode are fused inside one spawn_blocking so GPU mapped
     //   bytes flow directly to the encoder via callback (no intermediate Vec<u8>).
-    // - Default path: binarized is moved into the encoder; cloned only if OCR storage needs it.
+    // - Default path: binarized is moved into the encoder.
+    //
+    // The binarized/luma buffer is fully consumed by OCR (above) and the base-layer
+    // encoder; the PDF writer never reads a per-page binarized buffer (that field exists
+    // only for the separate DjVu writer). Keeping it out of `ProcessedPage` avoids towing
+    // a full-page grayscale buffer per page through the process→writer channel and the
+    // writer's out-of-order reorder buffer — a major OOM source on large OCR jobs.
     let adjusted_image = Arc::new(adjusted_image);
-    let (base_layer, binarized_for_page) = if config.text_format() == "jpeg" {
+    let base_layer = if config.text_format() == "jpeg" {
         let layer =
             encode_base_layer_for_jpeg_mode(Arc::clone(&adjusted_image), &config, page_index)
                 .await?;
-        let stored = if config.enable_ocr() {
-            Some(binarized)
-        } else {
-            None
-        };
-        (layer, stored)
+        drop(binarized);
+        layer
     } else if let Some(bin_options) = deferred_binarize {
-        let layer = encode_base_layer_fused(
+        encode_base_layer_fused(
             adjusted_image,
             bin_options,
             width,
@@ -486,15 +487,9 @@ async fn process_single_page(
             page_index,
             force_jbig2_generic,
         )
-        .await?;
-        (layer, None)
+        .await?
     } else {
-        let stored = if config.enable_ocr() {
-            Some(binarized.clone())
-        } else {
-            None
-        };
-        let layer = encode_base_layer(
+        encode_base_layer(
             binarized,
             width,
             height,
@@ -502,8 +497,7 @@ async fn process_single_page(
             page_index,
             force_jbig2_generic,
         )
-        .await?;
-        (layer, stored)
+        .await?
     };
 
     elements.insert(
@@ -523,7 +517,6 @@ async fn process_single_page(
         height: height as u32,
         elements,
         hocr_text,
-        binarized: binarized_for_page,
     })
 }
 
@@ -2101,7 +2094,10 @@ pub async fn create_and_run_pdf_source_pipeline(
                     elements: processed_page.elements,
                     hocr_text: processed_page.hocr_text,
                     index: processed_page.index,
-                    binarized: processed_page.binarized, // Already Option<Vec<u8>>
+                    // PDF assembly never reads Page::binarized (it's for the DjVu writer);
+                    // leaving it None keeps full-page grayscale buffers out of the writer's
+                    // reorder buffer.
+                    binarized: None,
                 };
 
                 pdf_writer_handle


### PR DESCRIPTION
Two independent memory fixes aimed at the out-of-memory crashes reported
on memory-constrained Windows machines.

1. Stop towing an unused per-page binarized buffer through the PDF path.
   The PDF writer (StreamingPdfBuilder::add_page) only reads `elements` and
   `hocr_text`; the per-page binarized buffer exists solely for the separate
   DjVu writer. The PDF pipeline was still cloning that full-page grayscale
   buffer (when OCR is enabled) and carrying it on every ProcessedPage/Page
   through the process->writer channel and the writer's out-of-order reorder
   buffer, which can hold dozens of pages. OCR already consumes the buffer
   before this point, so it was dead weight. Drop `binarized` from
   ProcessedPage and never populate Page::binarized on the PDF path. Output
   is byte-identical and the removed clone makes the hot path slightly cheaper.

2. Make the memory-pressure limit machine-adaptive. The backpressure ratio is
   current_usage / limit, but the limit was hard-coded to 12 GB, so on the
   4-8 GB machines that actually OOM the Critical threshold (~10.8 GB working
   set) is unreachable and wait_for_memory_relief() never engages. Derive the
   limit from physical RAM (~70%, clamped to [3, 12] GB) so the existing
   dynamic backpressure throttles rendering before the OS kills the process,
   while leaving well-resourced machines at full speed.

https://claude.ai/code/session_01Adit1i6zvNUDragFZU947q