### PR TITLE
Overlay slow-OCR text layer onto reflowed pages by reusing reflow detections

### DIFF
--- a/lege-ocr/src/lib.rs
+++ b/lege-ocr/src/lib.rs
@@ -83,6 +83,35 @@ impl OcrPipeline {
         Self { engine, config }
     }
 
+    /// OCR a single pre-cropped grayscale line image.
+    ///
+    /// Unlike [`process_page`], this skips layout detection and line
+    /// segmentation: the caller has already isolated one text line (for example
+    /// a source text-row already detected by the reflow pipeline). Word
+    /// bounding boxes in the returned result are in the crop's own pixel space
+    /// (crop-local), and `bbox_highres` spans the whole crop. Returns `None`
+    /// when the engine produces no usable text.
+    pub fn ocr_gray_line(&self, gray_img: &image::GrayImage) -> Option<OcrLineResult> {
+        if gray_img.width() == 0 || gray_img.height() == 0 {
+            return None;
+        }
+        let (gray_ocr, scale_x, scale_y) = normalize::prepare_line_for_ocr(gray_img, false);
+        match self.engine.ocr_line(&gray_ocr, &self.config.language) {
+            Ok(mut result) if !result.text.trim().is_empty() => {
+                rescale_word_bboxes(
+                    &mut result,
+                    scale_x,
+                    scale_y,
+                    gray_img.width(),
+                    gray_img.height(),
+                );
+                result.bbox_highres = [0, 0, gray_img.width(), gray_img.height()];
+                Some(result)
+            }
+            _ => None,
+        }
+    }
+
     /// Process a single page.
     ///
     /// `high_res`: the page rendered at full resolution (same pixel space as `binary`).

--- a/src/ocr/fast.rs
+++ b/src/ocr/fast.rs
@@ -4,12 +4,15 @@
 /// the hOCR helpers in `lege_ocr::hocr`. This module owns the tokio semaphore
 /// and the async wrapper/fan-out logic.
 use anyhow::Result;
+use image::RgbImage;
 use once_cell::sync::Lazy;
 use tokio::sync::Semaphore;
 
 use lege_ocr::engine::default_engine;
 use lege_ocr::fast as ocr_fast;
 use lege_ocr::hocr::{adjust_offsets, finalize, strip_to_body};
+
+use crate::reflow::{PlacedKind, PxRect, ReflowPage};
 
 /// Limit concurrent OCR operations to avoid WinRT / Tesseract memory pressure.
 pub static OCR_SEMAPHORE: Lazy<Semaphore> = Lazy::new(|| {
@@ -171,4 +174,215 @@ pub async fn perform_tiling_based_ocr(
     }
 
     Ok(finalize(&stitched, page_width, page_height))
+}
+
+//==============================================================================
+// Reflow ↔ fast-OCR integration
+//==============================================================================
+//
+// The fast path is the direct analog of slow-OCR's reflow integration. Instead
+// of recognizing source crops and re-projecting them, it OCRs the *composed
+// reflow raster* — the final page image, with text already at its reflowed
+// output positions — and reuses reflow's layout to decide where to look. The
+// reflowed placements are grouped into vertically-contiguous text blocks (the
+// same notion of "region" the streaming fast path gets from layout detection),
+// each block is OCR'd out of the binarized composed page, and its hOCR is
+// stitched back at the block's output position. Because every block is a rigid
+// rectangle on the composed page, a single offset re-projects recognition
+// exactly onto the reflowed text — no per-word matching needed.
+
+/// Build a page-level hOCR text layer for a *reflowed* output page with the fast
+/// OCR engine. `composed` is the final reflowed page raster (output-pixel
+/// space); the returned hOCR is expressed in those same coordinates so the
+/// invisible text overlays the reflowed bitmaps. Returns `None` when the page
+/// has no recognizable text.
+pub async fn perform_reflow_page_fast_ocr(
+    page: &ReflowPage,
+    composed: &RgbImage,
+    language: &str,
+) -> Result<Option<String>> {
+    // Fail fast if the engine is unavailable, so reflow pages aren't silently
+    // emitted without the text layer the user asked for.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    crate::ocr::check_tesseract_availability_for_language(language)
+        .map_err(|e| anyhow::anyhow!("OCR engine unavailable: {e}"))?;
+
+    let blocks = reflow_output_text_blocks(page);
+    if blocks.is_empty() {
+        return Ok(None);
+    }
+
+    let page_width = composed.width() as usize;
+    let page_height = composed.height() as usize;
+    if page_width == 0 || page_height == 0 {
+        return Ok(None);
+    }
+    let binarized = binarize_composed(composed);
+
+    let mut tasks = Vec::new();
+    for rect in blocks {
+        let bbox = [
+            rect.x as f32,
+            rect.y as f32,
+            rect.right() as f32,
+            rect.bottom() as f32,
+        ];
+        let (region_data, rw, rh) =
+            match ocr_fast::extract_region(&binarized, page_width, page_height, bbox) {
+                Ok(region) => region,
+                Err(e) => {
+                    log::warn!("reflow OCR region extract failed at {bbox:?}: {e}");
+                    continue;
+                }
+            };
+        let lang = language.to_string();
+        tasks.push(tokio::spawn(async move {
+            let hocr = perform_ocr_on_binarized(region_data, rw, rh, &lang)
+                .await
+                .ok();
+            (hocr, bbox)
+        }));
+    }
+
+    let mut stitched = String::new();
+    for res in futures::future::join_all(tasks).await {
+        match res {
+            Ok((Some(hocr), bbox)) => {
+                let body = strip_to_body(&hocr);
+                if !body.trim().is_empty() {
+                    let adjusted =
+                        adjust_offsets(&body, bbox[0].round() as i32, bbox[1].round() as i32);
+                    stitched.push_str(&adjusted);
+                }
+            }
+            Ok((None, bbox)) => log::warn!("reflow OCR produced no text at {bbox:?}"),
+            Err(e) => log::warn!("reflow OCR task failed: {e}"),
+        }
+    }
+
+    if stitched.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(finalize(&stitched, page_width, page_height)))
+}
+
+/// Binarize a composed reflow raster (black text on white) into the 1bpp buffer
+/// the fast engine expects: `0` = ink, `255` = background.
+fn binarize_composed(img: &RgbImage) -> Vec<u8> {
+    img.pixels()
+        .map(|p| {
+            let luma = (p[0] as u32 * 30 + p[1] as u32 * 59 + p[2] as u32 * 11) / 100;
+            if luma < 128 { 0 } else { 255 }
+        })
+        .collect()
+}
+
+/// Group a reflowed page's text placements into vertically-contiguous blocks in
+/// output-page coordinates. Words sharing an output row first merge into lines
+/// (by vertical-band overlap); lines separated by no more than a body line's
+/// height then merge into a block, so paragraph spacers and figures — which
+/// reflow renders as larger vertical gaps — naturally split blocks apart.
+fn reflow_output_text_blocks(page: &ReflowPage) -> Vec<PxRect> {
+    let mut rects: Vec<PxRect> = page
+        .items
+        .iter()
+        .filter(|it| matches!(it.kind, PlacedKind::Word | PlacedKind::Run))
+        .map(|it| it.out_rect)
+        .filter(|r| !r.is_empty())
+        .collect();
+    if rects.is_empty() {
+        return Vec::new();
+    }
+    rects.sort_by_key(|r| (r.y, r.x));
+
+    // Merge placements that share an output row into line rectangles.
+    let mut lines: Vec<PxRect> = Vec::new();
+    for r in rects {
+        if let Some(last) = lines.last_mut() {
+            let overlap = last.bottom().min(r.bottom()).saturating_sub(last.y.max(r.y));
+            let h = r.h.max(1);
+            if (overlap as f32) >= 0.5 * (h as f32) {
+                *last = last.union(&r);
+                continue;
+            }
+        }
+        lines.push(r);
+    }
+
+    // Median line height sets the gap threshold for merging lines into blocks.
+    let mut heights: Vec<u32> = lines.iter().map(|l| l.h).collect();
+    heights.sort_unstable();
+    let median_h = heights[heights.len() / 2].max(1);
+
+    let mut blocks: Vec<PxRect> = Vec::new();
+    for l in lines {
+        if let Some(last) = blocks.last_mut() {
+            let gap = l.y.saturating_sub(last.bottom());
+            if gap <= median_h {
+                *last = last.union(&l);
+                continue;
+            }
+        }
+        blocks.push(l);
+    }
+    blocks
+}
+
+#[cfg(test)]
+mod reflow_fast_tests {
+    use super::*;
+    use crate::reflow::{PlacedItem, PlacedKind, PxRect, ReflowPage, SourceRef};
+
+    fn word_item(x: u32, y: u32, w: u32, h: u32) -> PlacedItem {
+        PlacedItem {
+            out_rect: PxRect::new(x, y, w, h),
+            src: SourceRef {
+                page_index: 0,
+                rect: PxRect::new(0, 0, w, h),
+            },
+            scale: 1.0,
+            kind: PlacedKind::Word,
+        }
+    }
+
+    fn page_with(items: Vec<PlacedItem>) -> ReflowPage {
+        ReflowPage {
+            index: 0,
+            width: 600,
+            height: 800,
+            items,
+        }
+    }
+
+    #[test]
+    fn merges_words_into_lines_then_paragraph_blocks() {
+        // Two words on row 1, two on row 2 (tight leading) -> one block.
+        // A third row after a large spacer -> a separate block.
+        let page = page_with(vec![
+            word_item(0, 0, 40, 20),
+            word_item(50, 0, 40, 20),
+            word_item(0, 26, 40, 20),
+            word_item(50, 26, 40, 20),
+            word_item(0, 200, 40, 20),
+        ]);
+        let blocks = reflow_output_text_blocks(&page);
+        assert_eq!(blocks.len(), 2);
+        // First block spans both tight rows and the full word width.
+        assert_eq!(blocks[0], PxRect::new(0, 0, 90, 46));
+        // Second block is the isolated row after the spacer.
+        assert_eq!(blocks[1], PxRect::new(0, 200, 40, 20));
+    }
+
+    #[test]
+    fn ignores_empty_pages() {
+        let page = page_with(Vec::new());
+        assert!(reflow_output_text_blocks(&page).is_empty());
+    }
+
+    #[test]
+    fn binarize_splits_ink_from_background() {
+        let mut img = RgbImage::from_pixel(2, 1, image::Rgb([255, 255, 255]));
+        img.put_pixel(0, 0, image::Rgb([0, 0, 0]));
+        assert_eq!(binarize_composed(&img), vec![0, 255]);
+    }
 }

--- a/src/ocr/slow.rs
+++ b/src/ocr/slow.rs
@@ -2,15 +2,17 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use anyhow::Result;
-use image::RgbImage;
+use image::{GrayImage, RgbImage};
 
 use lege_ocr::{
     OcrPipeline, SlowOcrConfig, coordinate::CoordinateMap, coordinate::scale_lines, hocr,
-    normalize, types::TextRegion,
+    normalize,
+    types::{OcrLineResult, OcrWord, TextRegion},
 };
 
 use crate::engine::Detection;
 use crate::pipeline::config::PipelineConfig;
+use crate::reflow::{PlacedKind, PxRect, ReflowPage, SourcePageImage};
 use crate::types::ContentCategory;
 
 thread_local! {
@@ -152,4 +154,442 @@ pub async fn perform_slow_ocr(
     let hocr = hocr::build_page_hocr(&slow_page.lines, output_width, output_height);
 
     Ok(Some(hocr))
+}
+
+//==============================================================================
+// Reflow ↔ slow-OCR integration
+//==============================================================================
+//
+// When raster reflow and slow OCR are both enabled, the reflow stage has
+// already detected the page's text rows and word spans (see
+// `reflow::reflow_page_flow`) and re-composed them onto new output pages. Rather
+// than re-running layout detection + line segmentation, we reuse those
+// detections: each reflowed text item (`PlacedKind::Word`) carries both the
+// source rectangle it was lifted from (`src`) and the rectangle it now occupies
+// on the output page (`out_rect`). Words from one source row share an identical
+// source `y`/height, so we can reconstruct each source line, OCR it once at
+// source resolution (best accuracy), then re-project the recognized words onto
+// their reflowed output positions. The result is a text layer whose words
+// overlay the reflowed bitmaps exactly.
+
+/// One reflowed text item: where it came from and where it landed.
+struct ReflowWord {
+    src_page: usize,
+    src_rect: PxRect,
+    out_rect: PxRect,
+}
+
+/// A word's source x-range within a row crop, tied back to its placement.
+struct WordSlot {
+    placement_index: usize,
+    local_x0: u32,
+    local_x1: u32,
+}
+
+/// One OCR job: a grayscale crop of a whole source row plus the word slots it
+/// must be split back into.
+struct RowJob {
+    crop: GrayImage,
+    slots: Vec<WordSlot>,
+}
+
+/// A recognized word positioned in output-page coordinates.
+struct OutputWord {
+    rect: PxRect,
+    text: String,
+    confidence: Option<f32>,
+}
+
+/// Build a page-level hOCR text layer for a *reflowed* output page by reusing
+/// the text-row / word regions the reflow stage already detected.
+///
+/// `sources` are the rendered source pages reflow composed from (high-resolution
+/// when slow OCR is active, since `source_render_height` scales them up). The
+/// returned hOCR is expressed in `page`'s output-pixel coordinates — the space
+/// the PDF/DJVU writer maps 1:1 onto the page — so the invisible text overlays
+/// the reflowed bitmaps. Returns `None` when the page has no recognizable text.
+pub async fn perform_reflow_page_ocr(
+    page: &ReflowPage,
+    sources: &[SourcePageImage],
+    config: &PipelineConfig,
+) -> Result<Option<String>> {
+    // Gather reflowed text items. Figures and tables carry no recognizable
+    // inline text and are skipped.
+    let placements: Vec<ReflowWord> = page
+        .items
+        .iter()
+        .filter(|item| matches!(item.kind, PlacedKind::Word | PlacedKind::Run))
+        .filter(|item| !item.out_rect.is_empty() && !item.src.rect.is_empty())
+        .map(|item| ReflowWord {
+            src_page: item.src.page_index,
+            src_rect: item.src.rect,
+            out_rect: item.out_rect,
+        })
+        .collect();
+    if placements.is_empty() {
+        return Ok(None);
+    }
+
+    // Group placements by source text row: words from one row share
+    // (source page, source y, source height). A `BTreeMap` keeps the row order
+    // deterministic.
+    let mut groups: std::collections::BTreeMap<(usize, u32, u32), Vec<usize>> =
+        std::collections::BTreeMap::new();
+    for (i, w) in placements.iter().enumerate() {
+        groups
+            .entry((w.src_page, w.src_rect.y, w.src_rect.h))
+            .or_default()
+            .push(i);
+    }
+
+    // Build one OCR job per source row: a gray crop spanning all its words and
+    // the per-word source x-ranges (relative to the crop origin).
+    let mut jobs: Vec<RowJob> = Vec::new();
+    for indices in groups.values() {
+        let first = &placements[indices[0]];
+        let Some(source) = sources.get(first.src_page) else {
+            continue;
+        };
+        let gray = &source.gray;
+        let y0 = first.src_rect.y;
+        let h = first.src_rect.h;
+        let mut x0 = u32::MAX;
+        let mut x1 = 0u32;
+        for &idx in indices {
+            let r = placements[idx].src_rect;
+            x0 = x0.min(r.x);
+            x1 = x1.max(r.right());
+        }
+        if x1 <= x0 || h == 0 || x1 > gray.width() || y0.saturating_add(h) > gray.height() {
+            continue;
+        }
+        let crop = image::imageops::crop_imm(gray, x0, y0, x1 - x0, h).to_image();
+        let mut slots: Vec<WordSlot> = indices
+            .iter()
+            .map(|&idx| {
+                let r = placements[idx].src_rect;
+                WordSlot {
+                    placement_index: idx,
+                    local_x0: r.x.saturating_sub(x0),
+                    local_x1: r.right().saturating_sub(x0),
+                }
+            })
+            .collect();
+        slots.sort_by_key(|s| s.local_x0);
+        jobs.push(RowJob { crop, slots });
+    }
+    if jobs.is_empty() {
+        return Ok(None);
+    }
+
+    let language = config.ocr_language().to_string();
+
+    // OCR is synchronous and the engine is cached per worker thread, so run all
+    // row crops on the blocking pool. Returns (placement_index, text, conf).
+    let recognized: Vec<(usize, String, Option<f32>)> = tokio::task::spawn_blocking(move || {
+        PIPELINES.with(|cell| {
+            let mut pipelines = cell.borrow_mut();
+            let pipeline = pipelines.entry(language.clone()).or_insert_with(|| {
+                OcrPipeline::new(SlowOcrConfig {
+                    language: language.clone(),
+                    debug: false,
+                    debug_out_dir: None,
+                    ..Default::default()
+                })
+            });
+            let mut out: Vec<(usize, String, Option<f32>)> = Vec::new();
+            for job in &jobs {
+                if let Some(line) = pipeline.ocr_gray_line(&job.crop) {
+                    assign_words_to_slots(&line, &job.slots, &mut out);
+                }
+            }
+            out
+        })
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("reflow OCR task panicked: {e}"))?;
+
+    // Attach recognized text to the reflowed output rectangles.
+    let mut out_words: Vec<OutputWord> = recognized
+        .into_iter()
+        .filter(|(_, text, _)| !text.trim().is_empty())
+        .map(|(idx, text, confidence)| OutputWord {
+            rect: placements[idx].out_rect,
+            text,
+            confidence,
+        })
+        .collect();
+    if out_words.is_empty() {
+        return Ok(None);
+    }
+
+    // Order top-to-bottom, left-to-right and group into output lines so the
+    // text layer reads naturally for selection / search.
+    out_words.sort_by_key(|w| (w.rect.y, w.rect.x));
+    let lines = group_output_lines(out_words);
+    let hocr = hocr::build_page_hocr(&lines, page.width, page.height);
+    Ok(Some(hocr))
+}
+
+/// Distribute a recognized line's words back onto the row's word slots by
+/// best source-x overlap, accumulating into `out` as (placement_index, text,
+/// average confidence). Both segmentations are gap-based over the same pixels,
+/// so x-overlap reliably matches OCR words to reflow words even when the counts
+/// differ (a merged OCR word goes to the slot it overlaps most; multiple OCR
+/// words in one slot are concatenated).
+fn assign_words_to_slots(
+    line: &OcrLineResult,
+    slots: &[WordSlot],
+    out: &mut Vec<(usize, String, Option<f32>)>,
+) {
+    if slots.is_empty() {
+        return;
+    }
+    let mut texts: Vec<String> = vec![String::new(); slots.len()];
+    let mut conf_sum: Vec<f32> = vec![0.0; slots.len()];
+    let mut conf_cnt: Vec<u32> = vec![0; slots.len()];
+
+    if line.words.is_empty() {
+        // No word-level boxes: drop the whole line onto the leftmost slot.
+        let t = line.text.trim();
+        if !t.is_empty() {
+            texts[0].push_str(t);
+            if let Some(c) = line.confidence {
+                conf_sum[0] += c;
+                conf_cnt[0] += 1;
+            }
+        }
+    } else {
+        for word in &line.words {
+            let t = word.text.trim();
+            if t.is_empty() {
+                continue;
+            }
+            let wx0 = word.bbox_crop_local[0];
+            let wx1 = word.bbox_crop_local[2];
+            let mut best = 0usize;
+            let mut best_overlap = 0i64;
+            for (si, slot) in slots.iter().enumerate() {
+                let lo = wx0.max(slot.local_x0);
+                let hi = wx1.min(slot.local_x1);
+                let overlap = hi as i64 - lo as i64;
+                if overlap > best_overlap {
+                    best_overlap = overlap;
+                    best = si;
+                }
+            }
+            // No overlap with any slot: fall back to the nearest slot center.
+            if best_overlap <= 0 {
+                let center = (wx0 + wx1) / 2;
+                best = slots
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, s)| {
+                        let c = (s.local_x0 + s.local_x1) / 2;
+                        (c as i64 - center as i64).abs()
+                    })
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+            }
+            if !texts[best].is_empty() {
+                texts[best].push(' ');
+            }
+            texts[best].push_str(t);
+            if let Some(c) = word.confidence {
+                conf_sum[best] += c;
+                conf_cnt[best] += 1;
+            }
+        }
+    }
+
+    for (si, slot) in slots.iter().enumerate() {
+        if texts[si].trim().is_empty() {
+            continue;
+        }
+        let conf = (conf_cnt[si] > 0).then(|| conf_sum[si] / conf_cnt[si] as f32);
+        out.push((slot.placement_index, std::mem::take(&mut texts[si]), conf));
+    }
+}
+
+/// Group output-positioned words (pre-sorted by `(y, x)`) into hOCR lines,
+/// starting a new line when a word's vertical span no longer overlaps the
+/// current line's band by at least half its height.
+fn group_output_lines(words: Vec<OutputWord>) -> Vec<OcrLineResult> {
+    let mut lines: Vec<OcrLineResult> = Vec::new();
+    let mut current: Vec<OutputWord> = Vec::new();
+    let mut band_top = 0u32;
+    let mut band_bot = 0u32;
+
+    for w in words {
+        let wt = w.rect.y;
+        let wb = w.rect.bottom();
+        let start_new = !current.is_empty() && {
+            let overlap = band_bot.min(wb).saturating_sub(band_top.max(wt));
+            let h = wb.saturating_sub(wt).max(1);
+            (overlap as f32) < 0.5 * (h as f32)
+        };
+        if start_new {
+            lines.push(finish_line(std::mem::take(&mut current)));
+        }
+        if current.is_empty() {
+            band_top = wt;
+            band_bot = wb;
+        } else {
+            band_top = band_top.min(wt);
+            band_bot = band_bot.max(wb);
+        }
+        current.push(w);
+    }
+    if !current.is_empty() {
+        lines.push(finish_line(current));
+    }
+    lines
+}
+
+/// Assemble one output line's words into an `OcrLineResult`. Word boxes are
+/// stored crop-local (relative to the line origin) because `hocr::build_line_hocr`
+/// offsets them by the line's `bbox_highres` origin.
+fn finish_line(mut words: Vec<OutputWord>) -> OcrLineResult {
+    words.sort_by_key(|w| w.rect.x);
+    let mut x0 = u32::MAX;
+    let mut y0 = u32::MAX;
+    let mut x1 = 0u32;
+    let mut y1 = 0u32;
+    for w in &words {
+        x0 = x0.min(w.rect.x);
+        y0 = y0.min(w.rect.y);
+        x1 = x1.max(w.rect.right());
+        y1 = y1.max(w.rect.bottom());
+    }
+    let text = words
+        .iter()
+        .map(|w| w.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let ocr_words = words
+        .into_iter()
+        .map(|w| OcrWord {
+            bbox_crop_local: [
+                w.rect.x.saturating_sub(x0),
+                w.rect.y.saturating_sub(y0),
+                w.rect.right().saturating_sub(x0),
+                w.rect.bottom().saturating_sub(y0),
+            ],
+            text: w.text,
+            confidence: w.confidence,
+        })
+        .collect();
+    OcrLineResult {
+        text,
+        confidence: None,
+        words: ocr_words,
+        bbox_highres: [x0, y0, x1, y1],
+    }
+}
+
+#[cfg(test)]
+mod reflow_ocr_tests {
+    use super::*;
+
+    fn ocr_word(text: &str, x0: u32, x1: u32, conf: f32) -> OcrWord {
+        OcrWord {
+            text: text.to_string(),
+            bbox_crop_local: [x0, 0, x1, 10],
+            confidence: Some(conf),
+        }
+    }
+
+    fn slot(placement_index: usize, x0: u32, x1: u32) -> WordSlot {
+        WordSlot {
+            placement_index,
+            local_x0: x0,
+            local_x1: x1,
+        }
+    }
+
+    fn out_word(x: u32, y: u32, w: u32, h: u32, text: &str) -> OutputWord {
+        OutputWord {
+            rect: PxRect::new(x, y, w, h),
+            text: text.to_string(),
+            confidence: None,
+        }
+    }
+
+    #[test]
+    fn assigns_recognized_words_to_slots_by_x_overlap() {
+        let line = OcrLineResult {
+            text: "the cat".to_string(),
+            confidence: Some(0.9),
+            words: vec![ocr_word("the", 0, 28, 0.9), ocr_word("cat", 40, 70, 0.8)],
+            bbox_highres: [0, 0, 70, 10],
+        };
+        let slots = vec![slot(5, 0, 30), slot(9, 38, 72)];
+        let mut out = Vec::new();
+        assign_words_to_slots(&line, &slots, &mut out);
+        out.sort_by_key(|(i, _, _)| *i);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], (5, "the".to_string(), Some(0.9)));
+        assert_eq!(out[1].0, 9);
+        assert_eq!(out[1].1, "cat");
+    }
+
+    #[test]
+    fn merged_recognized_word_goes_to_best_overlap_slot() {
+        // One OCR word spanning both word slots is assigned to the slot it
+        // overlaps most (40px vs 9px), not split.
+        let line = OcrLineResult {
+            text: "hello".to_string(),
+            confidence: None,
+            words: vec![ocr_word("hello", 0, 50, 0.5)],
+            bbox_highres: [0, 0, 50, 10],
+        };
+        let slots = vec![slot(1, 0, 40), slot(2, 41, 60)];
+        let mut out = Vec::new();
+        assign_words_to_slots(&line, &slots, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0, 1);
+        assert_eq!(out[0].1, "hello");
+    }
+
+    #[test]
+    fn wordless_line_drops_text_on_first_slot() {
+        let line = OcrLineResult {
+            text: "fallback".to_string(),
+            confidence: Some(0.4),
+            words: Vec::new(),
+            bbox_highres: [0, 0, 80, 10],
+        };
+        let slots = vec![slot(7, 0, 80)];
+        let mut out = Vec::new();
+        assign_words_to_slots(&line, &slots, &mut out);
+        assert_eq!(out, vec![(7, "fallback".to_string(), Some(0.4))]);
+    }
+
+    #[test]
+    fn groups_output_words_into_lines_by_vertical_band() {
+        let words = vec![
+            out_word(0, 0, 20, 10, "a"),
+            out_word(25, 0, 20, 10, "b"),
+            out_word(0, 30, 20, 10, "c"),
+        ];
+        let lines = group_output_lines(words);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].text, "a b");
+        assert_eq!(lines[0].words.len(), 2);
+        assert_eq!(lines[1].text, "c");
+    }
+
+    #[test]
+    fn finish_line_emits_line_local_word_boxes() {
+        let line = finish_line(vec![
+            out_word(40, 100, 20, 10, "y"),
+            out_word(10, 100, 20, 10, "x"),
+        ]);
+        // Words are sorted left-to-right and the line bbox is their union.
+        assert_eq!(line.bbox_highres, [10, 100, 60, 110]);
+        assert_eq!(line.text, "x y");
+        // Word boxes are relative to the line origin (10, 100).
+        assert_eq!(line.words[0].bbox_crop_local, [0, 0, 20, 10]);
+        assert_eq!(line.words[1].bbox_crop_local, [30, 0, 50, 10]);
+    }
 }

--- a/src/pipeline/reflow_pipeline.rs
+++ b/src/pipeline/reflow_pipeline.rs
@@ -413,17 +413,25 @@ pub(crate) async fn run_raster_reflow_pipeline(
             ));
         }
 
-        let canvas = compose_reflow_page_raster(reflow_page, &source_pages, &reflow_cfg);
-        let encoded =
-            encode_base_layer_for_jpeg_mode(Arc::new(canvas), &config, reflow_page.index).await?;
+        let canvas = Arc::new(compose_reflow_page_raster(reflow_page, &source_pages, &reflow_cfg));
 
-        // When slow OCR is enabled, overlay a searchable text layer onto the
-        // reflowed page by recognizing the reflow-detected text rows and
-        // re-projecting the words onto their new output positions.
-        let hocr_text = if config.enable_ocr() && config.slow_ocr_enabled() {
-            match crate::ocr::slow::perform_reflow_page_ocr(reflow_page, &source_pages, &config)
+        // Overlay a searchable text layer onto the reflowed page, reusing the
+        // text rows / words reflow already detected. Slow OCR recognizes the
+        // source crops and re-projects each word; fast OCR recognizes the
+        // composed reflow raster block-by-block. Either way the hOCR lands in
+        // output-page coordinates so the text overlays the reflowed bitmaps.
+        let hocr_text = if config.enable_ocr() {
+            let result = if config.slow_ocr_enabled() {
+                crate::ocr::slow::perform_reflow_page_ocr(reflow_page, &source_pages, &config).await
+            } else {
+                crate::ocr::fast::perform_reflow_page_fast_ocr(
+                    reflow_page,
+                    &canvas,
+                    config.ocr_language(),
+                )
                 .await
-            {
+            };
+            match result {
                 Ok(hocr) => hocr,
                 Err(e) => {
                     warn_log!(
@@ -437,6 +445,8 @@ pub(crate) async fn run_raster_reflow_pipeline(
         } else {
             None
         };
+
+        let encoded = encode_base_layer_for_jpeg_mode(canvas, &config, reflow_page.index).await?;
 
         let page = crate::accumulator::Page {
             width: reflow_page.width as f32,

--- a/src/pipeline/reflow_pipeline.rs
+++ b/src/pipeline/reflow_pipeline.rs
@@ -417,6 +417,27 @@ pub(crate) async fn run_raster_reflow_pipeline(
         let encoded =
             encode_base_layer_for_jpeg_mode(Arc::new(canvas), &config, reflow_page.index).await?;
 
+        // When slow OCR is enabled, overlay a searchable text layer onto the
+        // reflowed page by recognizing the reflow-detected text rows and
+        // re-projecting the words onto their new output positions.
+        let hocr_text = if config.enable_ocr() && config.slow_ocr_enabled() {
+            match crate::ocr::slow::perform_reflow_page_ocr(reflow_page, &source_pages, &config)
+                .await
+            {
+                Ok(hocr) => hocr,
+                Err(e) => {
+                    warn_log!(
+                        "[Reflow] Page {}: OCR text layer failed: {}",
+                        reflow_page.index,
+                        e
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let page = crate::accumulator::Page {
             width: reflow_page.width as f32,
             height: reflow_page.height as f32,
@@ -427,7 +448,7 @@ pub(crate) async fn run_raster_reflow_pipeline(
                 height: reflow_page.height as f32,
                 content: encoded,
             }],
-            hocr_text: None,
+            hocr_text,
             index: reflow_page.index,
             binarized: None,
         };


### PR DESCRIPTION
When both raster reflow and slow OCR are enabled, the reflow pipeline
previously wrote pages with no text layer (hocr_text: None), so OCR was
silently dropped in reflow mode. The two stages also overlap: reflow
already detects text rows and word spans and re-composes them onto new
output pages, while slow OCR independently re-runs region detection and
line segmentation.

Reuse reflow's detections instead of recomputing them. Each reflowed text
item carries the source rectangle it was lifted from and the rectangle it
now occupies on the output page, and words from one source row share an
identical source y/height. perform_reflow_page_ocr() groups placements
back into source rows, OCRs each row once at source resolution for
accuracy, then re-projects the recognized words onto their reflowed output
positions by source-x overlap. The resulting hOCR is built in output-page
coordinates so the invisible text overlays the reflowed bitmaps exactly.

- lege-ocr: add OcrPipeline::ocr_gray_line() to recognize a pre-cropped
  text-row image (no layout detection / segmentation), returning crop-local
  word boxes.
- reflow_pipeline: when enable_ocr() && slow_ocr_enabled(), build the
  text layer per output page instead of writing hocr_text: None.
- Unit-test the word-to-slot assignment and output-line grouping helpers.

https://claude.ai/code/session_01AokCcfRybvju4g6dqBMaVm